### PR TITLE
This should fix the use of the logging functions.

### DIFF
--- a/lfe.config
+++ b/lfe.config
@@ -1,4 +1,7 @@
-#(project (
+#(project
+  (#(deps (#("rvirding/lfe" "develop")
+           #("lfex/lcfg" "master")
+           #("lfex/logjam" "master")))
   #(meta (
     #(name rcrly)
     #(description "An Erlang/LFE Client for the Recurly Billing REST API")

--- a/lfe.config
+++ b/lfe.config
@@ -2,16 +2,15 @@
   (#(deps (#("rvirding/lfe" "develop")
            #("lfex/lcfg" "master")
            #("lfex/logjam" "master")))
-  #(meta (
-    #(name rcrly)
-    #(description "An Erlang/LFE Client for the Recurly Billing REST API")
-    #(version "0.0.1")
-    #(keywords ("LFE" "Lisp" "Library" "REST" "Billing" "Finance"))
-    #(maintainers (
-      (#(name "Cinova Engineering") #(email "dev@cinova.co"))))
-    #(repos (
-      #(github "cinova/rcrly")))))))
-
+   #(meta (
+     #(name rcrly)
+     #(description "An Erlang/LFE Client for the Recurly Billing REST API")
+     #(version "0.0.1")
+     #(keywords ("LFE" "Lisp" "Library" "REST" "Billing" "Finance"))
+     #(maintainers (
+       (#(name "Cinova Engineering") #(email "dev@cinova.co"))))
+     #(repos (
+       #(github "cinova/rcrly")))))))
 #(logging (
    #(log-level info)
    #(backend lager)


### PR DESCRIPTION
Calling the logging functions wasn't working out of the box -- it was only working on systems that had the latest lcfg, lutil, and lfetool installs. These changes cause the latest versions of these to be used (overriding rebar's limitations).

This _does_ require, however, that the user have the latest _development_ version (dev-v1 branch) of lfetool installed.
